### PR TITLE
Adds Guarani currency symbol

### DIFF
--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -110,7 +110,7 @@
 
         <tr>
           <th class="text-left" *ngFor="let salary of getKeys(salary)">
-            {{salary | currency:'Gs.': 'symbol' : '1.0'}}
+            {{salary | currency:'₲': 'symbol' : '1.0'}}
           </th>
         </tr>
 


### PR DESCRIPTION
This adds the official Guarani currency symbol ₲ instead of the usual Gs.

Signed-off-by: Diego Ramírez <diegocrzt@gmail.com>